### PR TITLE
log a direct link to cdn (ssl) path

### DIFF
--- a/packages/yoshi/src/tasks/cdn/index.js
+++ b/packages/yoshi/src/tasks/cdn/index.js
@@ -40,7 +40,7 @@ module.exports = async ({
     }
   }
 
-  console.log(`\tRunning cdn on port ${port}...`);
+  console.log(`\tRunning cdn on http://localhost:${port}`);
 
   let middlewares = [];
 

--- a/packages/yoshi/src/tasks/cdn/index.js
+++ b/packages/yoshi/src/tasks/cdn/index.js
@@ -40,7 +40,8 @@ module.exports = async ({
     }
   }
 
-  console.log(`\tRunning cdn on http://localhost:${port}`);
+  const protocol = ssl ? 'https' : 'http';
+  console.log(`\tRunning cdn on ${protocol}://localhost:${port}`);
 
   let middlewares = [];
 


### PR DESCRIPTION
### 🔦 Summary
Log a full path to the cdn instead of only the port. example:
Running cdn on {port_number} => Running cdn on http://localhost:{port_number}